### PR TITLE
Bug ouverture modale

### DIFF
--- a/projects/sandouich/src/lib/service/modal.service.ts
+++ b/projects/sandouich/src/lib/service/modal.service.ts
@@ -1,11 +1,11 @@
 import { Injectable } from '@angular/core';
-import { Subject } from 'rxjs';
+import { BehaviorSubject } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ModalService {
-  display: Subject<boolean> = new Subject<boolean>();
+  display = new BehaviorSubject(false);
   status = false;
 
   constructor() { }


### PR DESCRIPTION
Pour afficher la modale, il fallait exécuter deux fois la méthode d'ouverture de la modale, a cause du Subject. 
Changé par un BehaviorSubject